### PR TITLE
chore(release): New release [0.1.44]

### DIFF
--- a/projects/galileo/CHANGELOG.md
+++ b/projects/galileo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.1.44 (2020-10-30)
+
 ### 0.1.43 (2020-10-19)
 
 ### 0.1.42 (2020-10-14)

--- a/projects/galileo/package-lock.json
+++ b/projects/galileo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicolalopatriello/galileo",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/galileo/package.json
+++ b/projects/galileo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicolalopatriello/galileo",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "homepage": "https://github.com/nicolalopatriello/galileo",
   "author": {
     "name": "Nicola Lopatriello",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.1.44].