### PR TITLE
chore(release): New release [0.1.119]

### DIFF
--- a/projects/galileo/CHANGELOG.md
+++ b/projects/galileo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.1.119 (2021-03-19)
+
 ### 0.1.118 (2021-03-19)
 
 ### 0.1.117 (2021-03-19)

--- a/projects/galileo/package-lock.json
+++ b/projects/galileo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicolalopatriello/galileo",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/galileo/package.json
+++ b/projects/galileo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicolalopatriello/galileo",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "homepage": "https://github.com/nicolalopatriello/galileo",
   "author": {
     "name": "Nicola Lopatriello",
@@ -20,7 +20,6 @@
     "@angular/forms": ">= 9.1.6 <= 10.1.1",
     "@angular/platform-browser": ">= 9.1.6 <= 10.1.1",
     "@angular/router": ">= 9.1.6 <= 10.1.1",
-
     "@fortawesome/angular-fontawesome": ">=  0.6.0 <= 0.7.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.1.119].