### PR TITLE
chore(release): New release [0.1.147]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2598,43 +2598,6 @@
         }
       }
     },
-    "@fortawesome/angular-fontawesome": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.7.0.tgz",
-      "integrity": "sha512-U+eHYbKuVYrrm9SnIfl+z+6KTiI4Pu+S2OKh34JIi7C1jHhDcrVeDZISP/cpswHY7LWWDOPYeKE+yuWFlL4aVw==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",
-      "integrity": "sha512-ux2EDjKMpcdHBVLi/eWZynnPxs0BtFVXJkgHIxXRl+9ZFaHPvYamAfCzeeQFqHRjuJtX90wVnMRaMQAAlctz3w=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.32",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.32.tgz",
-      "integrity": "sha512-XjqyeLCsR/c/usUpdWcOdVtWFVjPbDFBTQkn2fQRrWhhUoxriQohO2RWDxLyUM8XpD+Zzg5xwJ8gqTYGDLeGaQ==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.32"
-      }
-    },
-    "@fortawesome/free-regular-svg-icons": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.1.tgz",
-      "integrity": "sha512-eD9NWFy89e7SVVtrLedJUxIpCBGhd4x7s7dhesokjyo1Tw62daqN5UcuAGu1NrepLLq1IeAYUVfWwnOjZ/j3HA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.32"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.1.tgz",
-      "integrity": "sha512-EFMuKtzRMNbvjab/SvJBaOOpaqJfdSap/Nl6hst7CgrJxwfORR1drdTV6q1Ib/JVzq4xObdTDcT6sqTaXMqfdg==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.32"
-      }
-    },
     "@hapi/hoek": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",

--- a/projects/galileo/CHANGELOG.md
+++ b/projects/galileo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.1.147 (2021-04-29)
+
 ### 0.1.146 (2021-04-29)
 
 ### 0.1.145 (2021-04-29)

--- a/projects/galileo/package-lock.json
+++ b/projects/galileo/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicolalopatriello/galileo",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/galileo/package.json
+++ b/projects/galileo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nicolalopatriello/galileo",
-  "version": "0.1.146",
+  "version": "0.1.147",
   "homepage": "https://github.com/nicolalopatriello/galileo",
   "author": {
     "name": "Nicola Lopatriello",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [0.1.147].